### PR TITLE
Add compression ratio in s3bench.go#L136-L137

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,10 @@ Put times 50th %ile: 0.001 s
 Put times 25th %ile: 0.001 s
 Put times Min:       0.001 s
 ```
+
+##### Head-object
+It is possible to send head-object requests instead of get-object.
+For this purpose one sould use *-metaData* flag
+```
+./s3bench -accessKey=KEY -accessSecret=SECRET -bucket=loadgen -endpoint=http://endpoint1:80 -numClients=2 -numSamples=10 -objectNamePrefix=loadgen -objectSize=1024 -metaData
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/412fa22ba5f8452794584ed9819f149b)](https://www.codacy.com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Seagate/s3bench&amp;utm_campaign=Badge_Grade)
+
 # Initial
 Cloned from
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Initial
+Cloned from
+```
+https://github.com/igneous-systems/s3bench.git
+```
+
 # S3 Bench
 This tool offers the ability to run very basic throughput benchmarking against
 an S3-compatible endpoint. It does a series of put operations followed by a

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+now=$(date +'%Y-%m-%d-%T')
+githash=$(git rev-parse HEAD)
+
+echo "Building version $now-$githash..."
+
+go build -ldflags "-X main.gitHash=$githash -X main.buildDate=$now"
+
+echo "Complete"

--- a/data_decl.go
+++ b/data_decl.go
@@ -1,0 +1,65 @@
+package main
+
+import "time"
+
+var (
+	gitHash   string
+	buildDate string
+)
+
+const (
+	opRead  = "Read"
+	opWrite = "Write"
+	opHeadObj = "HeadObj"
+	opGetObjTag = "GetObjTag"
+	opPutObjTag = "PutObjTag"
+	opValidate = "Validate"
+)
+
+type Req struct {
+	top string
+	req interface{}
+}
+
+type Resp struct {
+	err      error
+	duration time.Duration
+	numBytes int64
+	ttfb     time.Duration
+}
+
+// Specifies the parameters for a given test
+type Params struct {
+	requests         chan Req
+	responses        chan Resp
+	numSamples       uint
+	numClients       uint
+	objectSize       int64
+	objectNamePrefix string
+	bucketName       string
+	endpoints        []string
+	verbose          bool
+	headObj          bool
+	sampleReads      uint
+	clientDelay      int
+	jsonOutput       bool
+	deleteAtOnce     int
+	putObjTag        bool
+	getObjTag        bool
+	numTags          uint
+	readObj          bool
+	tagNamePrefix    string
+	tagValPrefix     string
+	reportFormat     string
+	validate         bool
+}
+
+// Contains the summary for a given test result
+type Result struct {
+	operation        string
+	bytesTransmitted int64
+	opDurations      []float64
+	totalDuration    time.Duration
+	opTtfb           []float64
+	opErrors         []string
+}

--- a/data_decl.go
+++ b/data_decl.go
@@ -52,6 +52,8 @@ type Params struct {
 	tagValPrefix     string
 	reportFormat     string
 	validate         bool
+	skipWrite        bool
+	skipRead         bool
 }
 
 // Contains the summary for a given test result

--- a/report.go
+++ b/report.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"encoding/json"
+)
+
+func keysSort(keys []string, format []string) []string {
+	sort.Strings(keys)
+	cur_formated := 0
+
+	for _, fv := range format {
+		fv = strings.TrimSpace(fv)
+		should_del := strings.HasPrefix(fv, "-")
+		if should_del {
+			fv = fv[1:]
+		}
+		ci := indexOf(keys, fv)
+		if ci < 0 {
+			continue
+		}
+		// delete old pos
+		keys = append(keys[:ci], keys[ci+1:]...)
+
+		if !should_del {
+			// insert new pos
+			keys = append(keys[:cur_formated], append([]string{fv}, keys[cur_formated:]...)...)
+			cur_formated++
+		}
+	}
+
+	return keys
+}
+
+func formatFilter(format []string, key string) []string {
+	ret := []string{}
+	for _, v := range format {
+		if strings.HasPrefix(v, key + ":") {
+			ret = append(ret, v[len(key + ":"):])
+		} else if strings.HasPrefix(v, "-" + key + ":") {
+			ret = append(ret, "-" + v[len("-" + key + ":"):])
+		}
+	}
+
+	return ret
+}
+
+func mapPrint(m map[string]interface{}, repFormat []string, prefix string) {
+	var mkeys []string
+	for k,_ := range m {
+		mkeys = append(mkeys, k)
+	}
+	mkeys = keysSort(mkeys, repFormat)
+	for _, k := range mkeys {
+		v := m[k]
+		fmt.Printf("%s %-27s", prefix, k+":")
+		switch val := v.(type) {
+		case []string:
+			if len(val) == 0 {
+				fmt.Printf(" []\n")
+			} else {
+				fmt.Println()
+				for _, s := range val {
+					fmt.Printf("%s%s %s\n", prefix, prefix, s)
+				}
+			}
+		case map[string]interface{}:
+			fmt.Println()
+			mapPrint(val, formatFilter(repFormat, k), prefix + "   ")
+		case []map[string]interface{}:
+			if len(val) == 0 {
+				fmt.Printf(" []\n")
+			} else {
+				val_format := formatFilter(repFormat, k)
+				for _, m := range val {
+					fmt.Println()
+					mapPrint(m, val_format, prefix + "   ")
+				}
+			}
+		case float64:
+			fmt.Printf(" %.3f\n", val)
+		default:
+			fmt.Printf(" %v\n", val)
+		}
+	}
+}
+
+func (params Params) reportPrepare(tests []Result) map[string]interface{} {
+	report := make(map[string]interface{})
+	report["Version"] = fmt.Sprintf("%s-%s", buildDate, gitHash)
+	report["Parameters"] = params.report()
+	testreps := make([]map[string]interface{}, 0, len(tests))
+	for _, r := range tests {
+		testreps = append(testreps, r.report())
+	}
+	report["Tests"] = testreps
+	return report
+}
+
+func (params Params) reportPrint(report map[string]interface{}) {
+	if params.jsonOutput {
+		b, err := json.Marshal(report)
+		if err != nil {
+			fmt.Println("Cannot generate JSON report %v", err)
+		}
+		fmt.Println(string(b))
+		return
+	}
+
+	mapPrint(report, strings.Split(params.reportFormat, ";"), "")
+}
+
+func (r Result) report() map[string]interface{} {
+	ret := make(map[string]interface{})
+	ret["Operation"] = r.operation
+	ret["Total Requests Count"] = len(r.opDurations)
+	if r.operation == opWrite || r.operation == opRead || r.operation == opValidate {
+		ret["Total Transferred (MB)"] = float64(r.bytesTransmitted)/(1024*1024)
+		ret["Total Throughput (MB/s)"] = (float64(r.bytesTransmitted)/(1024*1024))/r.totalDuration.Seconds()
+	}
+	ret["Total Duration (s)"] = r.totalDuration.Seconds()
+
+	if len(r.opDurations) > 0 {
+		ret["Duration Max"] = percentile(r.opDurations, 100)
+		ret["Duration Avg"] = avg(r.opDurations)
+		ret["Duration Min"] = percentile(r.opDurations, 0)
+		ret["Duration 99th-ile"] = percentile(r.opDurations, 99)
+		ret["Duration 90th-ile"] = percentile(r.opDurations, 90)
+		ret["Duration 75th-ile"] = percentile(r.opDurations, 75)
+		ret["Duration 50th-ile"] = percentile(r.opDurations, 50)
+		ret["Duration 25th-ile"] = percentile(r.opDurations, 25)
+	}
+
+	if len(r.opTtfb) > 0 {
+		ret["Ttfb Max"] = percentile(r.opTtfb, 100)
+		ret["Ttfb Avg"] = avg(r.opTtfb)
+		ret["Ttfb Min"] = percentile(r.opTtfb, 0)
+		ret["Ttfb 99th-ile"] = percentile(r.opTtfb, 99)
+		ret["Ttfb 90th-ile"] = percentile(r.opTtfb, 90)
+		ret["Ttfb 75th-ile"] = percentile(r.opTtfb, 75)
+		ret["Ttfb 50th-ile"] = percentile(r.opTtfb, 50)
+		ret["Ttfb 25th-ile"] = percentile(r.opTtfb, 25)
+	}
+
+	ret["Errors Count"] = len(r.opErrors)
+	ret["Errors"] = r.opErrors
+	return ret
+}
+
+func (params Params) report() map[string]interface{} {
+	ret := make(map[string]interface{})
+	ret["endpoints"] =  params.endpoints
+	ret["bucket"] = params.bucketName
+	ret["objectNamePrefix"] = params.objectNamePrefix
+	ret["objectSize (MB)"] = float64(params.objectSize)/(1024*1024)
+	ret["numClients"] = params.numClients
+	ret["numSamples"] = params.numSamples
+	ret["sampleReads"] = params.sampleReads
+	ret["verbose"] = params.verbose
+	ret["headObj"] = params.headObj
+	ret["clientDelay"] = params.clientDelay
+	ret["jsonOutput"] = params.jsonOutput
+	ret["deleteAtOnce"] = params.deleteAtOnce
+	ret["numTags"] = params.numTags
+	ret["putObjTag"] = params.putObjTag
+	ret["getObjTag"] = params.getObjTag
+	ret["readObj"] = params.readObj
+	ret["tagNamePrefix"] = params.tagNamePrefix
+	ret["tagValPrefix"] = params.tagValPrefix
+	ret["reportFormat"] = params.reportFormat
+	ret["validate"] = params.validate
+	return ret
+}

--- a/report.go
+++ b/report.go
@@ -171,5 +171,7 @@ func (params Params) report() map[string]interface{} {
 	ret["tagValPrefix"] = params.tagValPrefix
 	ret["reportFormat"] = params.reportFormat
 	ret["validate"] = params.validate
+	ret["skipWrite"] = params.skipWrite
+	ret["skipRead"] = params.skipRead
 	return ret
 }

--- a/s3bench.go
+++ b/s3bench.go
@@ -42,7 +42,8 @@ func (params *Params) prepareBucket(cfg *aws.Config) bool {
 
 	if err == nil {
 		return true
-	} else if !strings.Contains(err.Error(), "BucketAlreadyOwnedByYou:") {
+	} else if !strings.Contains(err.Error(), "BucketAlreadyOwnedByYou:") &&
+		!strings.Contains(err.Error(), "BucketAlreadyExists:") {
 		panic("Failed to create bucket: " + err.Error())
 	}
 

--- a/s3bench.go
+++ b/s3bench.go
@@ -86,14 +86,14 @@ func main() {
 	numSamples := flag.Int("numSamples", 200, "total number of requests to send")
 	skipCleanup := flag.Bool("skipCleanup", false, "skip deleting objects created by this tool at the end of the run")
 	verbose := flag.Bool("verbose", false, "print verbose per thread status")
-	metaData := flag.Bool("metaData", false, "read obj metadata instead of obj itself")
+	headObj := flag.Bool("headObj", false, "head-object request instead of reading obj content")
 	sampleReads := flag.Int("sampleReads", 1, "number of reads of each sample")
 	clientDelay := flag.Int("clientDelay", 1, "delay in ms before client starts. if negative value provided delay will be randomized in interval [0, abs{clientDelay})")
 	jsonOutput := flag.Bool("jsonOutput", false, "print results in forma of json")
 	deleteAtOnce := flag.Int("deleteAtOnce", 1000, "number of objs to delete at once")
 	putObjTag := flag.Bool("putObjTag", false, "put object's tags")
 	getObjTag := flag.Bool("getObjTag", false, "get object's tags")
-	numTags := flag.Int("numTags", 0, "number if tags")
+	numTags := flag.Int("numTags", 10, "number of tags")
 
 	flag.Parse()
 
@@ -115,8 +115,8 @@ func main() {
 	if *getObjTag {
 		*putObjTag = true
 
-		if *metaData {
-			fmt.Println("\"-metaData\" and \"-getObjTag\" cannt be specified simultaneously")
+		if *headObj {
+			fmt.Println("\"-headObj\" and \"-getObjTag\" cannt be specified simultaneously")
 			os.Exit(1)
 		}
 	}
@@ -140,7 +140,7 @@ func main() {
 		bucketName:       *bucketName,
 		endpoints:        strings.Split(*endpoint, ","),
 		verbose:          *verbose,
-		metaData:         *metaData,
+		headObj:          *headObj,
 		sampleReads:      uint(*sampleReads),
 		clientDelay:      *clientDelay,
 		jsonOutput:       *jsonOutput,
@@ -184,7 +184,7 @@ func main() {
 	if params.getObjTag {
 		params.printf("Running %s test...\n", opGetObjTag)
 		testResults = append(testResults, params.Run(opGetObjTag))
-	} else if params.metaData {
+	} else if params.headObj {
 		params.printf("Running %s test...\n", opHeadObj)
 		testResults = append(testResults, params.Run(opHeadObj))
 	} else {
@@ -417,7 +417,7 @@ type Params struct {
 	bucketName       string
 	endpoints        []string
 	verbose          bool
-	metaData         bool
+	headObj          bool
 	sampleReads      uint
 	clientDelay      int
 	jsonOutput       bool
@@ -490,7 +490,7 @@ func (params Params) report() map[string]interface{} {
 	ret["numSamples"] = params.numSamples
 	ret["sampleReads"] = params.sampleReads
 	ret["verbose"] = params.verbose
-	ret["metaData"] = params.metaData
+	ret["headObj"] = params.headObj
 	ret["clientDelay"] = params.clientDelay
 	ret["jsonOutput"] = params.jsonOutput
 	ret["deleteAtOnce"] = params.deleteAtOnce

--- a/s3bench.go
+++ b/s3bench.go
@@ -22,6 +22,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+var (
+	gitHash   string
+	buildDate string
+)
+
 const (
 	opRead  = "Read"
 	opWrite = "Write"
@@ -96,8 +101,14 @@ func main() {
 	numTags := flag.Int("numTags", 10, "number of tags to create, for objects it should in range [1..10]")
 	tagNamePrefix := flag.String("tagNamePrefix", "tag_name_", "prefix of the tag name that will be used")
 	tagValPrefix := flag.String("tagValPrefix", "tag_val_", "prefix of the tag value that will be used")
+	version := flag.Bool("version", false, "print version info")
 
 	flag.Parse()
+
+	if *version {
+		fmt.Printf("%s-%s\n", buildDate, gitHash)
+		os.Exit(0)
+	}
 
 	if *numClients > *numSamples || *numSamples < 1 {
 		fmt.Printf("numClients(%d) needs to be less than numSamples(%d) and greater than 0\n", *numClients, *numSamples)
@@ -497,6 +508,7 @@ func (params Params) report() map[string]interface{} {
 
 func (params Params) reportPrepare(tests []Result) map[string]interface{} {
 	report := make(map[string]interface{})
+	report["Version"] = fmt.Sprintf("%s-%s", buildDate, gitHash)
 	report["Parameters"] = params.report()
 	testreps := make([]map[string]interface{}, 0, len(tests))
 	for _, r := range tests {

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"regexp"
+	"encoding/base32"
+)
+
+func to_b32(dt []byte) string {
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(dt)
+}
+
+func from_b32(s string) ([]byte, error) {
+	return base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(s)
+}
+
+func parse_size(sz string) int64 {
+	sizes := map[string]int64 {
+		"b": 1,
+		"Kb": 1024,
+		"Mb": 1024 * 1024,
+		"Gb": 1024 * 1024 * 1024,
+	}
+	re := regexp.MustCompile(`^(\d+)([bKMG]{1,2})$`)
+	mm := re.FindStringSubmatch(sz)
+	if len(mm) != 3 {
+		panic("Invalid objectSize value format\n")
+	}
+	val, err := strconv.ParseInt(string(mm[1]), 10, 64)
+	mult, ex := sizes[string(mm[2])]
+	if !ex || err != nil {
+		panic("Invalid objectSize value\n")
+	}
+	return val * mult
+}
+
+func (params Params) printf(f string, args ...interface{}) {
+	if params.verbose {
+		fmt.Printf(f, args...)
+	}
+}
+
+// samples per operation
+func (params Params) spo(op string) uint {
+	if op == opWrite || op == opPutObjTag || op == opValidate {
+		return params.numSamples
+	}
+
+	return params.numSamples * params.sampleReads
+}
+
+func percentile(dt []float64, i int) float64 {
+	ln := len(dt)
+	if i >= 100 {
+		i = ln - 1
+	} else if i > 0 && i < 100 {
+		i = int(float64(i) / 100 * float64(ln))
+	}
+	return dt[i]
+}
+
+func avg(dt []float64) float64 {
+	ln := float64(len(dt))
+	sm := float64(0)
+	for _, el := range dt {
+		sm += el
+	}
+	return sm / ln
+}
+
+func indexOf(sls []string, s string) int {
+	ret := -1
+	for i, v := range sls {
+		if v == s {
+			ret = i
+			break
+		}
+	}
+	return ret
+}


### PR DESCRIPTION
We need to make some random data and sprinkle it with a const value 


```
`
func fill_buffer(comp_percent int, size int) []byte {

	res := make([]byte, size)

	if comp_percent == 100 {
		return res
	}

	var rand_size int

	rand_size = (size * (100 - comp_percent)) / 100

	var source = rand.NewSource(time.Now().UnixNano())
	rand.New(source)
	rand.Read(res[0:rand_size])

	fmt.Println("Array:", res)

	rand.Shuffle(len(res), func(i, j int) {
		res[i], res[j] = res[j], res[i]
	})

	return res

}
`
```




The test for it is as follow



```

package main

import (
	"fmt"
	"math/rand"
	"time"
)

// fill_buffer provides a stream of compressible data
// Blanks/Zeros are added randomly amongst the random data stream
// It returns the data stream

func fill_buffer(comp_percent int, size int) []byte {

	res := make([]byte, size)

	if comp_percent == 100 {
		return res
	}

	var rand_size int

	rand_size = (size * (100 - comp_percent)) / 100

	var source = rand.NewSource(time.Now().UnixNano())
	rand.New(source)
	rand.Read(res[0:rand_size])

	fmt.Println("Array:", res)

	rand.Shuffle(len(res), func(i, j int) {
		res[i], res[j] = res[j], res[i]
	})

	return res

}
func main() {
	// fmt.Println("hello world")
	var size int

	var ratio int

	size = 4096
	ratio = 50

	resT := fill_buffer(ratio, size)
	fmt.Println(resT)
	fmt.Println("Slice:", resT)

	fmt.Println("Size was", size)

	fmt.Println("Ratio was", ratio)
}







```